### PR TITLE
fixing no message files exist break

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -16,6 +16,7 @@ class Parser:
         self.timezone = pytz.timezone(own_timezone)
         message_files = [thread_dir + ms_file for ms_file in os.listdir(thread_dir) if ms_file.endswith('.json')]
         self.messages = []
+        assert message_files, "No conversation files."
         for ms in message_files:
             with open(ms, 'r') as read_file:
                 ms_json = json.load(read_file)


### PR DESCRIPTION
Hello, 
so for a starter you made my life hell in debugging because the spaces, use tabs man :D . 
anyway, when i tried it, it broke on the parsing, after debugging i found there are users who have no message.json file in their directories, so the list message_files becomes empty, it won't go into the loop, and the participants list won't be created so it'll break with error "AttributeError: 'Parser' object has no attribute 'participants'", 
fixed it by putting assertion on message_files list. 
